### PR TITLE
Update links + add desc. of Camunda Community Hub

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A curated list of awesome [Zeebe](https://zeebe.io) projects, mostly driven by t
 
 ## Contributing
 
-Contributions are welcome, if you build something awesome with Zeebe please let us know. Take a quick gander at the [contribution guidelines](https://github.com/zeebe-io/awesome-zeebe/blob/master/CONTRIBUTING.md) first.
+Contributions are welcome, if you build something awesome with Zeebe please let us know. Take a quick gander at the [contribution guidelines](https://github.com/zeebe-io/awesome-zeebe/blob/master/CONTRIBUTING.md) first. If you would like, you can also join the [Camunda Community Hub](https://github.com/Camunda-Community-Hub/community/), which is a centralized home for all Camunda Community contributed extensions!
 
 *If you see a package or project here that is no longer maintained or is not a good fit, please submit a pull request to improve this file. Thank you!*
 
@@ -29,16 +29,16 @@ Contributions are welcome, if you build something awesome with Zeebe please let 
 - [Java](https://github.com/zeebe-io/zeebe/tree/master/clients/java)
   - [Spring](https://github.com/zeebe-io/spring-zeebe)
 - [Go](https://github.com/zeebe-io/zeebe/tree/master/clients/go)
-- [C#](https://github.com/zeebe-io/zeebe-client-csharp)
-- [Delphi](https://github.com/syconpmm/DelphiZeeBeClient)
+- [C#](https://github.com/camunda-community-hub/zeebe-client-csharp)
+- [Delphi](https://github.com/camunda-community-hub/DelphiZeeBeClient)
 - [Ruby](https://github.com/zeebe-io/zeebe-client-ruby)
   - [Beez](https://github.com/gottfrois/beez) - Simple, efficient ruby workers for Zeebe
 - [Node.js](https://github.com/camunda-community-hub/zeebe-client-node-js)
-  - [NestJS](https://www.npmjs.com/package/nestjs-zeebe)
-- [Rust](https://github.com/xmclark/zeebest)
+  - [NestJS](https://github.com/camunda-community-hub/nestjs-zeebe#readme)
+- [Rust](https://github.com/camunda-community-hub/zeebest)
 - Python:
   - [Zeebe Python gRPC](https://pypi.org/project/zeebe-grpc/)
-  - [Pyzeebe](https://github.com/JonatanMartens/pyzeebe)
+  - [Pyzeebe](https://github.com/camunda-community-hub/pyzeebe)
 - [WorkIt](https://github.com/VilledeMontreal/workit) - Node.js (TypeScript) client for both Zeebe and Camunda BPM platforms
 
 _**Want an exporter for another language?**_
@@ -50,19 +50,19 @@ Thanks to gRPC you can generate client stubs easily as described in [Generating 
 
 *Connector: A piece of software that connects Zeebe with some other system or infrastructure. Might be uni or bidirectional and possibly includes a job worker.*
 
-- [Kafka Connector](https://github.com/berndruecker/kafka-connect-zeebe)
-- [HTTP](https://github.com/zeebe-io/zeebe-http-worker) - Zeebe job worker for making HTTP calls
+- [Kafka Connector](https://github.com/camunda-community-hub/kafka-connect-zeebe)
+- [HTTP](https://github.com/camunda-community-hub/zeebe-http-worker) - Zeebe job worker for making HTTP calls
 - [Lambda](https://github.com/camunda-community-hub/zeebe-lambda-worker) - A Zeebe worker to invoke AWS Lambdas (Serverless functions), allowing to orchestrate functions
-- [Node-RED Zeebe nodes](https://github.com/pedesen/node-red-contrib-zeebe)
+- [Node-RED Zeebe nodes](https://github.com/camunda-community-hub/node-red-contrib-zeebe)
 - [Zeebe GitHub Action](https://github.com/marketplace/actions/zeebe-action) - Integrate Zeebe into GitHub Workflows with Camunda Cloud
 
 ## Job Workers
 
 *Job Worker: A special type of client that polls for and executes available jobs. In contrast to connectors and bridges, such workers do not connect to other active pieces of software primarily (for example, a 'DMN Connector' might connect Zeebe to a managed DMN Engine, a 'DMN worker' will use a DMN library to execute decisions).*
 
-- [Script](https://github.com/zeebe-io/zeebe-script-worker) - Zeebe job worker for evaluating JS, Groovy, and FEEL scripts
-- [DMN Scala](https://github.com/camunda/dmn-scala/tree/master/zeebe-worker) - Zeebe job worker using the [Scala DMN engine](https://github.com/camunda/dmn-scala)
-- [Camunda DMN](https://github.com/zeebe-io/zeebe-dmn-worker) - Zeebe job worker using the [Camunda DMN engine](https://github.com/camunda/camunda-engine-dmn)
+- [Script](https://github.com/camunda-community-hub/zeebe-script-worker) - Zeebe job worker for evaluating JS, Groovy, and FEEL scripts
+- [DMN Scala](https://github.com/camunda-community-hub/dmn-scala/tree/master/zeebe-worker) - Zeebe job worker using the [Scala DMN engine](https://github.com/camunda/dmn-scala)
+- [Camunda DMN](https://github.com/camunda-community-hub/zeebe-dmn-worker) - Zeebe job worker using the [Camunda DMN engine](https://github.com/camunda/camunda-engine-dmn)
 
 ## Exporters
 
@@ -70,9 +70,9 @@ Thanks to gRPC you can generate client stubs easily as described in [Generating 
 
 - [Elasticsearch](https://github.com/zeebe-io/zeebe/tree/master/exporters/elasticsearch-exporter)
 - [Event Store](https://github.com/jwulf/zeebe-eventstore-exporter)
-- [Hazelcast](https://github.com/zeebe-io/zeebe-hazelcast-exporter)
+- [Hazelcast](https://github.com/camunda-community-hub/zeebe-hazelcast-exporter)
 - [Incident Alerter (Webhook)](https://github.com/jwulf/zeebe-incident-alerter)
-- [Kafka](https://github.com/zeebe-io/zeebe-kafka-exporter)
+- [Kafka](https://github.com/camunda-community-hub/zeebe-kafka-exporter)
 - [CSV](https://github.com/zeebe-io/zeebe-csv-exporter)
 - [NATS Streaming Server](https://github.com/MrSaints/zeebe-nats-streaming-exporter)
 - [MongoDB](https://github.com/crossid/zeebe-mongo-exporter)
@@ -85,25 +85,25 @@ You can build one in as little as 15 minutes. Take a look at the [Zeebe Exporter
 
 *Applications to interact with Zeebe*
 
-- [Simple Monitor](https://github.com/zeebe-io/zeebe-simple-monitor) - A lightweight application for monitoring and interacting with Zeebe during development
-- [ZeeQS](https://github.com/zeebe-io/zeeqs) - GraphQL query API for aggregated Zeebe data
+- [Simple Monitor](https://github.com/camunda-community-hub/zeebe-simple-monitor) - A lightweight application for monitoring and interacting with Zeebe during development
+- [ZeeQS](https://github.com/camunda-community-hub/zeeqs) - GraphQL query API for aggregated Zeebe data
 - [Modeler](https://github.com/zeebe-io/zeebe-modeler) - Use Zeebe Modeler to model your workflow in a desktop application
 - [zbctl](https://github.com/zeebe-io/zeebe/tree/master/clients/zbctl) - CLI to interact with Zeebe
 - [zbctl via npm](https://www.npmjs.com/package/zbctl) - zbctl is just an `npm install` away
 - [dockerised zbctl](https://hub.docker.com/r/sitapati/zbctl) - See [these notes on using it in CI](https://forum.zeebe.io/t/use-docker-compose-cant-find-bpmn-file/1004/3?u=jwulf)
 - [Workflow Linter](https://github.com/StephenOTT/Workflow-Linter) - Workflow Linter for BPMN workflows
 - [Zeebe Cloud Canary](https://github.com/jwulf/zeebe-cloud-canary) - Monitor the aliveness of a Zeebe broker
-- [Zeebe Simple Tasklist](https://github.com/zeebe-io/zeebe-simple-tasklist) - Zeebe job worker for manual/user tasks
+- [Zeebe Simple Tasklist](https://github.com/camunda-community-hub/zeebe-simple-tasklist) - Zeebe job worker for manual/user tasks
 - [Quintessential Task List](https://github.com/StephenOTT/Quintessential-Tasklist-Zeebe) - The quintessential Zeebe tasklist for BPMN Human tasks with Drag and Drop Form builder, client and server side validations, and drop in Form Rendering
 
 ## Testing
 
 *Test utilities to help you develop Zeebe-dependent applications*
 
-- [Zeebe Test Container](https://github.com/zeebe-io/zeebe-test-container) - [TestContainers](https://testcontainers.org) module to help you write integration tests against configurable Zeebe instances.
+- [Zeebe Test Container](https://github.com/camunda-community-hub/zeebe-test-container) - [TestContainers](https://testcontainers.org) module to help you write integration tests against configurable Zeebe instances.
 - [Zeebe Chaos](https://github.com/zeebe-io/zeebe-chaos) - contains everything related to chaos engineering and Zeebe, like chaos experiments, an hypotheses backlog etc.
 - [Zeebe BPMN RSpec](https://github.com/ezcater/zeebe_bpmn_rspec) - Ruby gem to test workflow logic in Zeebe using RSpec.
-- [BPMN Spec](https://github.com/zeebe-io/bpmn-spec) - a tool to write tests for BPMN workflows on run them on Zeebe
+- [BPMN Spec](https://github.com/camunda-community-hub/bpmn-spec) - a tool to write tests for BPMN workflows on run them on Zeebe
 - [Zeebe Performance Benchmarking / Tuning Tool](https://zeebe.io/blog/2020/11/zeebe-performance-tool/) - a performance benchmarking and tuning spreadsheet from Camunda Consultant Falko Menge.
 
 ## Others


### PR DESCRIPTION
Updated links for extensions that migrated to the Camunda Community Hub, and also added a line of text regarding joining the community hub where relevant.